### PR TITLE
bindActivityOnClasses option added

### DIFF
--- a/pace.js
+++ b/pace.js
@@ -6,6 +6,7 @@
     __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
   defaultOptions = {
+    bindActivityOnClasses: [],
     catchupTime: 500,
     initialRate: .03,
     minTime: 500,
@@ -26,7 +27,7 @@
       lagThreshold: 3
     },
     ajax: {
-      trackMethods: ['GET'],
+      trackMethods: ['GET', 'POST'],
       trackWebSockets: true,
       ignoreURLs: []
     }
@@ -236,7 +237,7 @@
     }
 
     Bar.prototype.getElement = function() {
-      var targetElement;
+      var targetElement, bEls, _bEi, bE;
       if (this.el == null) {
         targetElement = document.querySelector(options.target);
         if (!targetElement) {
@@ -247,21 +248,52 @@
         document.body.className = document.body.className.replace(/pace-done/g, '');
         document.body.className += ' pace-running';
         this.el.innerHTML = '<div class="pace-progress">\n  <div class="pace-progress-inner"></div>\n</div>\n<div class="pace-activity"></div>';
+
         if (targetElement.firstChild != null) {
           targetElement.insertBefore(this.el, targetElement.firstChild);
         } else {
           targetElement.appendChild(this.el);
         }
+
+        bEls = this.getBindedElements();
+        for (_bEi in bEls) {
+          bE = bEls[_bEi];
+          bE.className = bE.className.replace('pace-bind', '');
+          bE.className += ' pace-bind';
+        }
       }
       return this.el;
     };
 
+    Bar.prototype.getBindedElements = function() {
+      var _ei, _ec, el;
+
+      if (this.bindedElements == null) {
+        this.bindedElements = [];
+        for (_ei in options.bindActivityOnClasses) {
+          _ec = options.bindActivityOnClasses[_ei].replace('.', '');
+          el = document.querySelector('.'+_ec);
+          if (el) {
+            this.bindedElements.push(el);
+          }
+        }
+      }
+      return this.bindedElements;
+    };
+
     Bar.prototype.finish = function() {
-      var el;
+      var el, bEls;
       el = this.getElement();
       el.className = el.className.replace('pace-active', '');
       el.className += ' pace-inactive';
       document.body.className = document.body.className.replace('pace-running', '');
+
+      bEls = this.getBindedElements();
+      for (_bEi in bEls) {
+        bE = bEls[_bEi];
+        bE.className = bE.className.replace('pace-bind', '');
+      }
+
       return document.body.className += ' pace-done';
     };
 

--- a/tests/demo.html
+++ b/tests/demo.html
@@ -1,12 +1,12 @@
 <head>
-  <link rel="stylesheet" href="../themes/pace-theme-barber-shop.css" />
+  <link rel="stylesheet" href="../themes/pace-theme-flash-bind.css" />
 
   <script>
     paceOptions = {
       elements: true
     };
   </script>
-  <script src="../pace.js"></script>
+  <script data-pace-options='{ "bindActivityOnClasses" : ["square"] }' src="../pace.js"></script>
   <script>
     function load(time){
       var x = new XMLHttpRequest()
@@ -32,4 +32,8 @@
 
   </script>
 </head>
-<body></body>
+<body>
+<p><br /><br /></p>
+<div style="background: #999; height: 100px; width: 100px;" class="square"> Binded with Pace .pace-bind</div>
+
+</body>

--- a/themes/pace-theme-flash-bind.css
+++ b/themes/pace-theme-flash-bind.css
@@ -1,0 +1,89 @@
+/* This is a compiled file, you should be editing the file in the templates directory */
+.pace {
+  -webkit-pointer-events: none;
+  pointer-events: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
+}
+
+.pace-inactive {
+  display: none;
+}
+
+.pace .pace-progress {
+  background: #29d;
+  position: fixed;
+  z-index: 2000;
+  top: 0;
+  left: 0;
+  height: 2px;
+
+  -webkit-transition: width 1s;
+  -moz-transition: width 1s;
+  -o-transition: width 1s;
+  transition: width 1s;
+}
+
+.pace .pace-progress-inner {
+  display: block;
+  position: absolute;
+  right: 0px;
+  width: 100px;
+  height: 100%;
+  box-shadow: 0 0 10px #29d, 0 0 5px #29d;
+  opacity: 1.0;
+  -webkit-transform: rotate(3deg) translate(0px, -4px);
+  -moz-transform: rotate(3deg) translate(0px, -4px);
+  -ms-transform: rotate(3deg) translate(0px, -4px);
+  -o-transform: rotate(3deg) translate(0px, -4px);
+  transform: rotate(3deg) translate(0px, -4px);
+}
+
+.pace .pace-activity {
+  display: block;
+  position: fixed;
+  z-index: 2000;
+  top: 15px;
+  right: 15px;
+  width: 14px;
+  height: 14px;
+  border: solid 2px transparent;
+  border-top-color: #29d;
+  border-left-color: #29d;
+  border-radius: 10px;
+  -webkit-animation: pace-spinner 400ms linear infinite;
+  -moz-animation: pace-spinner 400ms linear infinite;
+  -ms-animation: pace-spinner 400ms linear infinite;
+  -o-animation: pace-spinner 400ms linear infinite;
+  animation: pace-spinner 400ms linear infinite;
+}
+
+.pace-bind {
+  -webkit-animation: pace-spinner 400ms linear infinite;
+  -moz-animation: pace-spinner 400ms linear infinite;
+  -ms-animation: pace-spinner 400ms linear infinite;
+  -o-animation: pace-spinner 400ms linear infinite;
+  animation: pace-spinner 400ms linear infinite;
+}
+
+@-webkit-keyframes pace-spinner {
+  0% { -webkit-transform: rotate(0deg); transform: rotate(0deg); }
+  100% { -webkit-transform: rotate(360deg); transform: rotate(360deg); }
+}
+@-moz-keyframes pace-spinner {
+  0% { -moz-transform: rotate(0deg); transform: rotate(0deg); }
+  100% { -moz-transform: rotate(360deg); transform: rotate(360deg); }
+}
+@-o-keyframes pace-spinner {
+  0% { -o-transform: rotate(0deg); transform: rotate(0deg); }
+  100% { -o-transform: rotate(360deg); transform: rotate(360deg); }
+}
+@-ms-keyframes pace-spinner {
+  0% { -ms-transform: rotate(0deg); transform: rotate(0deg); }
+  100% { -ms-transform: rotate(360deg); transform: rotate(360deg); }
+}
+@keyframes pace-spinner {
+  0% { transform: rotate(0deg); transform: rotate(0deg); }
+  100% { transform: rotate(360deg); transform: rotate(360deg); }
+}


### PR DESCRIPTION
This is based from issue [#111](https://github.com/HubSpot/pace/issues/111) I submitted. New option will get an array of class names that will be binded to pace's progress bar `{bindActivityOnClasses: ["square", "my-logo"]}`.

Pace will insert `.pace-bind` class to those elements hence will let you do anything with it in your theme.

``` css
/* my spinning div */
.pace-bind {
  -webkit-animation: pace-spinner 400ms linear infinite;
  -moz-animation: pace-spinner 400ms linear infinite;
  -ms-animation: pace-spinner 400ms linear infinite;
  -o-animation: pace-spinner 400ms linear infinite;
  animation: pace-spinner 400ms linear infinite;
}
```

Feel free to change code naming conventions (can't think of any). Thanks
