### PR TITLE
changed exports variable name to module

### DIFF
--- a/pace.js
+++ b/pace.js
@@ -924,7 +924,7 @@
     define(['pace'], function() {
       return Pace;
     });
-  } else if (typeof exports === 'object') {
+  } else if (typeof module === 'object') {
     module.exports = Pace;
   } else {
     if (options.startOnPageLoad) {


### PR DESCRIPTION
because i thought that you want to assign  Pace API object to module object as a exports property if it is an object.
