### PR TITLE
Fix extra spaces in class names

### DIFF
--- a/pace.js
+++ b/pace.js
@@ -244,8 +244,7 @@
         }
         this.el = document.createElement('div');
         this.el.className = "pace pace-active";
-        document.body.className = document.body.className.replace(/pace-done/g, '');
-        document.body.className += ' pace-running';
+        document.body.className = document.body.className.replace(/(pace-done)|/, 'pace-running');
         this.el.innerHTML = '<div class="pace-progress">\n  <div class="pace-progress-inner"></div>\n</div>\n<div class="pace-activity"></div>';
         if (targetElement.firstChild != null) {
           targetElement.insertBefore(this.el, targetElement.firstChild);
@@ -259,10 +258,9 @@
     Bar.prototype.finish = function() {
       var el;
       el = this.getElement();
-      el.className = el.className.replace('pace-active', '');
-      el.className += ' pace-inactive';
-      document.body.className = document.body.className.replace('pace-running', '');
-      return document.body.className += ' pace-done';
+      el.className = el.className.replace('pace-active', 'pace-inactive');
+      document.body.className = document.body.className.replace('pace-running', 'pace-done');
+      return document.body.className;
     };
 
     Bar.prototype.update = function(prog) {


### PR DESCRIPTION
The current way of switching class names for `body` and the `div.pace` creates extra spaces in front of some class names, for example: `pace-running` and `pace  pace-inactive`. 

This PR fixes this problem by using a slightly different way of replacing class names.
