### PR TITLE
Bower package name "PACE" > "pace"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "PACE",
+  "name": "pace",
   "main": "pace.js",
   "version": "1.0.2",
   "homepage": "http://github.hubspot.com/pace/docs/welcome",


### PR DESCRIPTION
Fix `bower invalid-meta  The "name" is recommended to be lowercase, can contain digits, dots, dashes`
