### PR TITLE
Fixes spelling mistake

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -172,7 +172,7 @@ whenever `pushState` or `replaceState` is called by default.
 
 - `Pace.track`: Explicitly track one or more requests, see Tracking below
 
-- `Pace.ignore`: Expliticly ignore one or more requests, see Tracking below
+- `Pace.ignore`: Explicitly ignore one or more requests, see Tracking below
 
 Events
 ------


### PR DESCRIPTION
changes `Explititly` to `Explicitly`