### PR TITLE
Fixes #199

### DIFF
--- a/pace.js
+++ b/pace.js
@@ -431,7 +431,7 @@
               request: req
             });
           }
-          return _open.apply(req, arguments);
+          return _open.call(req, type, url, async || true);
         };
       };
       window.XMLHttpRequest = function(flags) {


### PR DESCRIPTION
Fixes the following warning message:
`Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.`