### PR TITLE
Remove Google Analytics

### DIFF
--- a/docs/welcome/index.html
+++ b/docs/welcome/index.html
@@ -688,16 +688,6 @@
         </script>
         <!-- End of Async HubSpot Analytics Code -->
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-45159009-1', 'hubspot.com');
-          ga('send', 'pageview');
-        </script>
-
         <!-- Force 3d acceleration always and forever :) -->
         <div style="-webkit-transform: translateZ(0)"></div>
     </body>


### PR DESCRIPTION
Thanks for contributing to the FOSS ecosystem with your product!

I do have one question for you, though: would you be willing to replace the Google Analytics tracking code with something that respects user privacy and security? 

There are much better alternatives to Google Analytics, [which can be seen here.](https://switching.software/replace/google-analytics/)

As Google have been at the scene in the majority of court cases regarding [devious abuse of user privacy](https://en.wikipedia.org/wiki/Privacy_concerns_regarding_Google), we should seek to eliminate their influence from something they *can't* beat:

**Free, Open-Source Software.**

Instead of relying on a proprietary invasive product to generate analytical data about your project, perhaps you could try a FOSS alternative? I have gone to the trouble of creating a table, which details the advantages of each FOSS analytics solution:Here is a table of the annoyances of these analytics solutions.

|        | Fathom  | Freshlytics | Plausible | Goatcounter | Google [Analytics] | 
|------- | ------- | ----------- | --------- | ----------- | ---------------- |
| Issues | [cookies](https://github.com/usefathom/fathom#README) | *(none)* | *(none)* | *(none)* | Requires a Privacy Policy; collects IP information; Social interactions; Browsing history; GDPR cookie notice is required; ability to opt-out of tracking; creates an advertising profile of users |

Anyway, I hope we can work together to replace Google Analytics in your project! I love seeing FOSS move away from dependencies on proprietary technologies. I can't wait to see what happens!

Thanks,
Synth
