### PR TITLE
docs: Fix simple typo, seperate -> separate

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -117,7 +117,7 @@ Elements
 
 Elements being rendered to the screen is one way for us to decide that the page has been
 rendered.  If you would like to use that source of information (not required at all),
-specify one or more selectors.  You can comma seperate the selectors to propertly handle
+specify one or more selectors.  You can comma separate the selectors to propertly handle
 error states, where the progress bar should disappear, but the element we are looking for
 may never appear:
 


### PR DESCRIPTION
There is a small typo in docs/intro.md.

Should read `separate` rather than `seperate`.

