### PR TITLE
Fixing some Ajax calls not completing

### DIFF
--- a/pace.js
+++ b/pace.js
@@ -49,7 +49,25 @@
 	cancelAnimationFrame = window.cancelAnimationFrame || window.mozCancelAnimationFrame;
 
 	addEventListener = function(obj, event, callback) {
-		return (typeof obj.addEventListener === "function" ? obj.addEventListener(event, callback, false) : void 0) || (obj["on" + event] = callback);
+		if (typeof obj.addEventListener === "function") {
+			return obj.addEventListener(event, callback, false);
+		} else {
+			return function() {
+				if (typeof obj["on" + event] !== "function" || typeof obj["on" + event].eventListeners !== "object") {
+					var eventListeners = new Events();
+					if (typeof obj["on" + event] === "function") {
+						eventListeners.on(event, obj["on" + event]);
+					}
+					obj["on" + event] = function(evt) {
+						return eventListeners.trigger(event, evt);
+					};
+					obj["on" + event].eventListeners = eventListeners;
+				} else {
+					var eventListeners = obj["on" + event].eventListeners;
+				}
+				eventListeners.on(event, callback);
+			}();
+		}
 	};
 
 	if (requestAnimationFrame == null) {


### PR DESCRIPTION
obj["on" + event] was overwritten also when addEventListener was available.
Now adding an event fallback when addEventListener is unavailable.
The original event (when available) is first added to the list, and then one or more callbacks are added.

Fixes #509

Please update pace.min.js yourself.