### PR TITLE
Fix a bug when there's an error when starting or destroying the bar

### DIFF
--- a/pace.js
+++ b/pace.js
@@ -302,7 +302,11 @@
 			try {
 				this.getElement().parentNode.removeChild(this.getElement());
 			} catch (_error) {
-				NoTargetError = _error;
+				if (_error instanceof NoTargetError) {
+				   // This is ok
+				 } else {
+				   throw _error
+				 }
 			}
 			return this.el = void 0;
 		};
@@ -961,7 +965,11 @@
 		try {
 			bar.render();
 		} catch (_error) {
-			NoTargetError = _error;
+			if (_error instanceof NoTargetError) {
+			   // This is ok
+			 } else {
+			   throw _error
+			 }
 		}
 		if (!document.querySelector('.pace')) {
 			return setTimeout(Pace.start, 50);

--- a/pace.js
+++ b/pace.js
@@ -302,11 +302,7 @@
 			try {
 				this.getElement().parentNode.removeChild(this.getElement());
 			} catch (_error) {
-				if (_error instanceof NoTargetError) {
-				   // This is ok
-				 } else {
-				   throw _error
-				 }
+				// This is ok
 			}
 			return this.el = void 0;
 		};
@@ -965,11 +961,7 @@
 		try {
 			bar.render();
 		} catch (_error) {
-			if (_error instanceof NoTargetError) {
-			   // This is ok
-			 } else {
-			   throw _error
-			 }
+			// This is ok
 		}
 		if (!document.querySelector('.pace')) {
 			return setTimeout(Pace.start, 50);


### PR DESCRIPTION
Presumably this is incredibly unlikely to happen as I couldn't see any issues about this, and it's a bug that has been around for a very long time. 

There's an error class that gets defined, `NoTargetError`, that inherits from Error and is used in `Bar.prototype.getElement` when the target element doesn't exist in the DOM. However, there's a couple of places in the code where `NoTargetError` gets redefined inside of `catch {}` blocks, and assigned to the error _instance_ instead. Later, if the code tries to `throw new NoTargetError` again, it'll fail because the error instance is not a constructor.

I looked back at an older version of the repo to find the original Coffeescript source file: https://github.com/CodeByZach/pace/blob/v1.2.0/pace.coffee. I believe that the error handling in this file was just poorly written - they've used `catch NoTargetError`, and I believe the intention here is that _only_ NoTargetError errors should be caught. But the resulting compiled javascript code is:

```js
catch (_error) {
  NoTargetError = _error;
}
```

I've re-written those catch blocks as:

```js
catch (_error) {
  // This is ok
}
```

This means that all errors, including NoTargetError, will get caught and suppressed - the same behaviour as before. But the code no longer reassigns NoTargetError.

The original commit introducing NoTargetError and the catch block is here: https://github.com/CodeByZach/pace/commit/db587611564d06ee8218d9b63567eec121cc0642